### PR TITLE
consume unused props to prevent form warning

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -382,6 +382,8 @@ class Form extends React.Component {
       , value
       , component: Element
       , getter, setter
+      // consume non-form vars
+      , schema, errors, strict, delay // eslint-disable-line no-unused-vars
       , ...props } = this.props;
 
     if (Element === 'form')


### PR DESCRIPTION
Solves #67

I used one of the recommended methods 'consuming of props' that should not be passed, though I'm not sure it is the best way.  Code was already setup this way, though seems ugly since we need to disable linting for that line.

https://facebook.github.io/react/warnings/unknown-prop.html