### PR TITLE
Added a standalone proptypes lib to get rid of deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "lodash": "^3.10.1",
     "pick-attributes": "^1.0.2",
     "property-expr": "^1.3.1",
+    "proptypes": "^0.14.3",
     "react-input-message": "^0.14.1",
     "react-prop-types": "^0.3.2",
     "react-pure-render": "^1.0.2",

--- a/src/Form.js
+++ b/src/Form.js
@@ -7,6 +7,7 @@ import Container from 'react-input-message/MessageContainer';
 import uncontrollable from 'uncontrollable';
 import warning from 'warning';
 import reach from 'yup/lib/util/reach';
+import PropTypes from 'proptypes';
 
 import errorManager from './errorManager';
 import contextTypes from './util/contextType';
@@ -118,7 +119,7 @@ class Form extends React.Component {
      * Form value object, can be left [uncontrolled](/controllables);
      * use the `defaultValue` prop to initialize an uncontrolled form.
      */
-    value: React.PropTypes.object,
+    value: PropTypes.object,
 
     /**
      * Callback that is called when the `value` prop changes.
@@ -153,7 +154,7 @@ class Form extends React.Component {
      * }}/>
      * ```
      */
-    errors: React.PropTypes.object,
+    errors: PropTypes.object,
 
     /**
      * Callback that is called when a validation error occurs. It is called with an `errors` object
@@ -276,7 +277,7 @@ class Form extends React.Component {
      */
     schema(props, name, componentName, ...args) {
       var err = !props.noValidate &&
-        React.PropTypes.any.isRequired(props, name, componentName, ...args)
+        PropTypes.any.isRequired(props, name, componentName, ...args)
 
       if (props[name]) {
         let schema = props[name];
@@ -290,7 +291,7 @@ class Form extends React.Component {
     /**
      * yup schema context
      */
-    context: React.PropTypes.object,
+    context: PropTypes.object,
 
     /**
      * toggle debug mode, which `console.warn`s validation errors


### PR DESCRIPTION
As suggested in https://facebook.github.io/react/warnings/dont-call-proptypes.html#dont-call-proptypes-directly I added https://github.com/developit/proptypes to replace on props that had it's validation executed. I'm trying to solve #73 