### PR TITLE
Fix package.json homepage link

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Jason Quense",
     "email": "monastic.panic@gmail.com"
   },
-  "homepage": "http://jquense.github.io/react-formal/docs/",
+  "homepage": "http://jquense.github.io/react-formal/",
   "repository": {
     "type": "git",
     "url": "https://github.com/jquense/react-formal"


### PR DESCRIPTION
The homepage link in package.json currently points to http://jquense.github.io/react-formal/docs/. This page throws a 404. This PR fixes it.