### PR TITLE
Add checkbox as boolean alias input type

### DIFF
--- a/src/util/types.js
+++ b/src/util/types.js
@@ -38,7 +38,8 @@ types.array      =
   types.listbox  = wrapWithDefaults(SelectInput, { multiple: true })
 
 types.bool       =
-  types.boolean  = BoolInput
+  types.boolean  =
+  types.checkbox = BoolInput
 
 types.textarea   = wrapWithDefaults(Input, { tagName: 'textarea' })
 


### PR DESCRIPTION
I was pulling my hair why this wasn't working properly:

```jsx
<Form.Input type="checkbox" />
```

and then I found out that you named the `checkbox` input type as `boolean`.