### PR TITLE
use the prop-types package as accessing PropTypes via the main React package is deprecated

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,5 +1,6 @@
 /* eslint global-require: 0, react/prop-types: 0 */
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM, { render } from 'react-dom';
 import types from 'react-formal-inputs';
 import Form from '../src';
@@ -97,7 +98,7 @@ class Main extends React.Component {
 
 class App extends React.Component {
   static contextTypes = {
-    history: React.PropTypes.object
+    history: PropTypes.object
   }
 
   render(){

--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
     "release": "release"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.9 || >=15.3.0"
   },
   "dependencies": {
     "chain-function": "^1.0.0",
     "classnames": "^2.2.5",
     "invariant": "^2.2.1",
     "lodash": "^4.16.3",
+    "prop-types": "^15.5.0",
     "property-expr": "^1.3.1",
     "react-input-message": "^0.14.2",
     "react-prop-types": "^0.3.2",

--- a/src/Field.js
+++ b/src/Field.js
@@ -2,6 +2,7 @@
 import cn from 'classnames';
 import omit from 'lodash/omit';
 import React from 'react';
+import PropTypes from 'prop-types';
 import shallowEqual from 'react-pure-render/shallowEqual';
 import MessageTrigger from 'react-input-message/MessageTrigger';
 import { Binding } from 'topeka';
@@ -287,7 +288,7 @@ Field.propTypes = {
    *
    * ```
    */
-  name: React.PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
 
   /**
    * Group Fields together with a common `group` name. Groups can be
@@ -322,7 +323,7 @@ Field.propTypes = {
    * </Form>
    * ```
    */
-  group: React.PropTypes.string,
+  group: PropTypes.string,
 
   /**
    * The Component Input the form should render. You can sepcify a builtin type
@@ -360,17 +361,17 @@ Field.propTypes = {
    * You can also permenantly map Components to a string `type` name via the top-level
    * `addInputType()` api.
    */
-  type: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.string
+  type: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string
   ]),
 
   /**
    * Event name or array of event names that the Field should trigger a validation.
    */
-  events: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.arrayOf(React.PropTypes.string)
+  events: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
   ]),
 
   /**
@@ -413,10 +414,10 @@ Field.propTypes = {
    * </Form>
    * ```
    */
-  mapFromValue: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.string,
-    React.PropTypes.object
+  mapFromValue: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.string,
+    PropTypes.object
   ]),
 
   /**
@@ -432,15 +433,15 @@ Field.propTypes = {
    * />
    * ```
    */
-  mapToValue: React.PropTypes.oneOfType([
-    React.PropTypes.func,
-    React.PropTypes.object
+  mapToValue: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object
   ]),
 
   /**
    * The css class added to the Field Input when it fails validation
    */
-  errorClass: React.PropTypes.string,
+  errorClass: PropTypes.string,
 
   /**
    * Tells the Field to trigger validation for addition paths as well as its own (`name`).
@@ -452,9 +453,9 @@ Field.propTypes = {
    * <Form.Field name='name.last' alsoValidates={['name', 'surname']} />
    * ```
    */
-  alsoValidates:React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.arrayOf(React.PropTypes.string)
+  alsoValidates:PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string)
   ]),
 
   /**
@@ -469,12 +470,12 @@ Field.propTypes = {
    *
    * Are all considered "part" of a field named `'names'` by default.
    */
-  exclusive: React.PropTypes.bool,
+  exclusive: PropTypes.bool,
 
   /**
    * Disables validation for the Field.
    */
-  noValidate: React.PropTypes.bool,
+  noValidate: PropTypes.bool,
 
   /**
    * When children is the traditional react element or nodes, they are
@@ -500,15 +501,15 @@ Field.propTypes = {
    * </Field>
    * ```
    */
-  children: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.func,
+  children: PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.func,
   ]),
 
   /**
    * Instruct the field to not inject the `meta` prop into the input
    */
-  noMeta: React.PropTypes.bool,
+  noMeta: PropTypes.bool,
 }
 
 export default Field;

--- a/src/Form.js
+++ b/src/Form.js
@@ -2,6 +2,7 @@ import omit from 'lodash/omit'
 import pick from 'lodash/pick';
 import expr from 'property-expr';
 import React from 'react';
+import PropTypes from 'prop-types';
 import scu from 'react-pure-render/function';
 import Container from 'react-input-message/MessageContainer';
 import { BindingContext as BC } from 'topeka';
@@ -119,7 +120,7 @@ class Form extends React.Component {
      * Form value object, can be left [uncontrolled](/controllables);
      * use the `defaultValue` prop to initialize an uncontrolled form.
      */
-    value: React.PropTypes.object,
+    value: PropTypes.object,
 
     /**
      * Callback that is called when the `value` prop changes.
@@ -131,13 +132,13 @@ class Form extends React.Component {
      * )
      * ```
      */
-    onChange: React.PropTypes.func,
+    onChange: PropTypes.func,
 
     /**
      * A unique key that names a `Form` within a surrounding `Form.Context`.
      * Corresponding `Form.Button`s with the same `formKey` will trigger validation.
      */
-    formKey: React.PropTypes.string,
+    formKey: PropTypes.string,
 
     /**
      * An object hash of field errors for the form. The object should be keyed with paths
@@ -160,7 +161,7 @@ class Form extends React.Component {
      * }}/>
      * ```
      */
-    errors: React.PropTypes.object,
+    errors: PropTypes.object,
 
     /**
      * Callback that is called when a validation error occurs. It is called with an `errors` object
@@ -182,7 +183,7 @@ class Form extends React.Component {
      * </Form>
      * ```
      */
-    onError: React.PropTypes.func,
+    onError: PropTypes.func,
 
     /**
      * Callback that is called whenever a validation is triggered.
@@ -193,7 +194,7 @@ class Form extends React.Component {
      * }
      * ```
      */
-    onValidate: React.PropTypes.func,
+    onValidate: PropTypes.func,
 
     /**
      * Callback that is fired when the native onSubmit event is triggered. Only relevant when
@@ -205,7 +206,7 @@ class Form extends React.Component {
      * }
      * ```
      */
-    onSubmit: React.PropTypes.func,
+    onSubmit: PropTypes.func,
 
     /**
      * Callback that is fired when the native onSubmit event is triggered. Only relevant when
@@ -217,7 +218,7 @@ class Form extends React.Component {
      * }
      * ```
      */
-    onInvalidSubmit: React.PropTypes.func,
+    onInvalidSubmit: PropTypes.func,
 
     /**
      * A value getter function. `getter` is called with `path` and `value` and
@@ -230,7 +231,7 @@ class Form extends React.Component {
      * ) -> object
      * ```
      */
-    getter: React.PropTypes.func,
+    getter: PropTypes.func,
 
     /**
      * A value setter function. `setter` is called with `path`, the form `value` and the path `value`.
@@ -246,23 +247,23 @@ class Form extends React.Component {
      * ) -> object
      * ```
      */
-    setter: React.PropTypes.func,
+    setter: PropTypes.func,
 
     /**
      * Time in milliseconds that validations should be debounced. Reduces the amount of validation calls
      * made at the expense of a slight delay. Helpful for performance.
      */
-    delay: React.PropTypes.number,
+    delay: PropTypes.number,
 
     /**
      * Validations will be strict, making no attempt to coarce input values to the appropriate type.
      */
-    strict: React.PropTypes.bool,
+    strict: PropTypes.bool,
 
     /**
      * Turns off input validation for the Form, value updates will continue to work.
      */
-    noValidate: React.PropTypes.bool,
+    noValidate: PropTypes.bool,
 
     /**
      * A tag name or Component class the Form should render.
@@ -270,10 +271,10 @@ class Form extends React.Component {
      * If `null` are `false` the form will simply render it's child. In
      * this instance there must only be one child.
      */
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.func,
-      React.PropTypes.string,
-      React.PropTypes.oneOf([null, false])
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.oneOf([null, false])
     ]),
 
     /**
@@ -283,7 +284,7 @@ class Form extends React.Component {
      */
     schema(props, name, componentName, ...args) {
       var err = !props.noValidate &&
-        React.PropTypes.any.isRequired(props, name, componentName, ...args)
+        PropTypes.any.isRequired(props, name, componentName, ...args)
 
       if (props[name]) {
         let schema = props[name];
@@ -297,12 +298,12 @@ class Form extends React.Component {
     /**
      * yup schema context
      */
-    context: React.PropTypes.object,
+    context: PropTypes.object,
 
     /**
      * toggle debug mode, which `console.warn`s validation errors
      */
-    debug: React.PropTypes.bool,
+    debug: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -314,7 +315,7 @@ class Form extends React.Component {
   }
 
   static contextTypes = {
-    reactFormalContext: React.PropTypes.object
+    reactFormalContext: PropTypes.object
   }
 
   static childContextTypes = contextTypes

--- a/src/FormButton.js
+++ b/src/FormButton.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 import Trigger from 'react-input-message/MessageTrigger';
 
@@ -14,32 +15,32 @@ class Button extends React.Component {
     /**
      * The `<button/>` type
      */
-    type: React.PropTypes.oneOf(['button', 'submit']),
+    type: PropTypes.oneOf(['button', 'submit']),
 
     /**
      * Specify a group to validate, if empty the entire form will be validated.
      * If the button type is 'submit' the group will be ignored and the
      * entire form will be validated prior to submission.
      */
-    group: React.PropTypes.string,
+    group: PropTypes.string,
 
     /**
      * The key of `Form` that "owns" this button. Validation will be triggered
      * only for that `Form`.
      */
-    formKey: React.PropTypes.string,
+    formKey: PropTypes.string,
 
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func
+    component: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func
     ]),
 
     /**
      * An array of event names that trigger validation.
      */
-    events: React.PropTypes.arrayOf(React.PropTypes.string),
+    events: PropTypes.arrayOf(PropTypes.string),
 
-    onClick: React.PropTypes.func,
+    onClick: PropTypes.func,
   }
 
   static contextTypes = contextTypes

--- a/src/FormContext.js
+++ b/src/FormContext.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const DEFAULT_CHANNEL = '@@parent';
 
@@ -30,18 +31,18 @@ class FormContext extends React.Component {
    * @default 'div'
   **/
   static propTypes = {
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.func,
-      React.PropTypes.string
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string
     ])
   }
 
   static contextTypes = {
-    reactFormalContext: React.PropTypes.object
+    reactFormalContext: PropTypes.object
   }
 
   static childContextTypes = {
-    reactFormalContext: React.PropTypes.object
+    reactFormalContext: PropTypes.object
   }
 
   channels = Object.create(null);

--- a/src/ValidationMessage.js
+++ b/src/ValidationMessage.js
@@ -1,7 +1,8 @@
-import React from'react';
-import shouldComponentUpdate from'react-pure-render/function';
-import Message from'react-input-message/Message';
-import cn from'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import shouldComponentUpdate from 'react-pure-render/function';
+import Message from 'react-input-message/Message';
+import cn from 'classnames';
 
 import uniq from './util/uniqMessage';
 
@@ -25,22 +26,22 @@ class ValidationMessage extends React.Component {
      * </Message>
      * ```
      */
-    children: React.PropTypes.func,
+    children: PropTypes.func,
 
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.func,
-      React.PropTypes.string
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string
     ]).isRequired,
 
     /**
      * A css class that should be always be applied to the Message container.
      */
-    errorClass: React.PropTypes.string,
+    errorClass: PropTypes.string,
 
     /**
      * Map the passed in message object for the field to a string to display
      */
-    extract: React.PropTypes.func
+    extract: PropTypes.func
   }
 
   static defaultProps = {

--- a/src/ValidationSummary.js
+++ b/src/ValidationSummary.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import shouldComponentUpdate from 'react-pure-render/function';
 import ValidationMessage from './ValidationMessage';
 
@@ -36,25 +37,25 @@ class ValidationSummary extends React.Component {
      * ) -> ReactElement
      * ```
      */
-    formatMessage: React.PropTypes.func.isRequired,
+    formatMessage: PropTypes.func.isRequired,
 
     /**
      * A DOM node tag name or Component class the Message should render as.
      */
-    component: React.PropTypes.oneOfType([
-      React.PropTypes.func,
-      React.PropTypes.string
+    component: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string
     ]).isRequired,
 
     /**
      * A css class that should be always be applied to the Summary container.
      */
-    errorClass: React.PropTypes.string,
+    errorClass: PropTypes.string,
 
     /**
      * Specify a group to show erros for, if empty all form errors will be shown in the Summary.
      */
-    group: React.PropTypes.string
+    group: PropTypes.string
   }
 
   static defaultProps = {

--- a/src/inputs/Bool.js
+++ b/src/inputs/Bool.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Input from './Input';
 
 class BooleanInput extends React.Component {
   static propTypes = {
-    value: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
+    value: PropTypes.bool,
+    onChange: PropTypes.func,
   }
 
   render() {

--- a/src/inputs/Date.js
+++ b/src/inputs/Date.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Input from './Input';
 
 let pad = n => n < 10 ? ('0' + n) : n
@@ -38,9 +39,9 @@ let toDateString = (date, part) => {
 
 class DateInput extends React.Component {
   static propTypes = {
-    value: React.PropTypes.instanceOf(Date),
-    onChange: React.PropTypes.func,
-    type: React.PropTypes.string,
+    value: PropTypes.instanceOf(Date),
+    onChange: PropTypes.func,
+    type: PropTypes.string,
   }
 
   render() {

--- a/src/inputs/File.js
+++ b/src/inputs/File.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Input from './Input';
 
 class FileInput extends React.Component {
   static propTypes = {
-    multiple: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
+    multiple: PropTypes.bool,
+    onChange: PropTypes.func,
   }
 
   handleChange = ({ target: { files } }) => {

--- a/src/inputs/Input.js
+++ b/src/inputs/Input.js
@@ -1,12 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Input extends React.Component {
   static propTypes = {
-    value: React.PropTypes.any,
-    onChange: React.PropTypes.func,
-    tagName: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func,
+    value: PropTypes.any,
+    onChange: PropTypes.func,
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
     ]),
   };
   render() {

--- a/src/inputs/Number.js
+++ b/src/inputs/Number.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Input from './Input';
 
 let isValid = num => typeof num === 'number' && !isNaN(num)
@@ -10,8 +11,8 @@ let isAtDelimiter = (num, str) =>{
 
 class NumberInput extends React.Component {
   static propTypes = {
-    value: React.PropTypes.number,
-    onChange: React.PropTypes.func,
+    value: PropTypes.number,
+    onChange: PropTypes.func,
   }
 
   state = {}

--- a/src/inputs/Select.js
+++ b/src/inputs/Select.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import Input from './Input';
 
@@ -11,12 +12,12 @@ let toArray = React.Children.toArray || function (children) {
 
 class Select extends React.Component {
   static propTypes = {
-    value: React.PropTypes.any,
-    multiple: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
-    tagName: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.func,
+    value: PropTypes.any,
+    multiple: PropTypes.bool,
+    onChange: PropTypes.func,
+    tagName: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.func,
     ]),
   }
 

--- a/src/util/contextType.js
+++ b/src/util/contextType.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import PropTypes from 'prop-types';
 
 export default {
-  reactFormalContext: React.PropTypes.shape({
-    noValidate: React.PropTypes.bool,
-    schema: React.PropTypes.func,
-    onFieldError: React.PropTypes.func,
-    onSubmit: React.PropTypes.func,
-    onOptions: React.PropTypes.func
+  reactFormalContext: PropTypes.shape({
+    noValidate: PropTypes.bool,
+    schema: PropTypes.func,
+    onFieldError: PropTypes.func,
+    onSubmit: PropTypes.func,
+    onOptions: PropTypes.func
   })
 }

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Input from '../inputs/Input';
 import DateInput from '../inputs/Date';
 import NumberInput from '../inputs/Number';
@@ -11,9 +12,9 @@ let localDt = 'datetime-local'
 let wrapWithDefaults =
   (Component, defaults) => class extends React.Component {
     static propTypes = {
-      type: React.PropTypes.oneOfType([
-        React.PropTypes.string,
-        React.PropTypes.func,
+      type: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
       ]),
     };
 

--- a/test/form.js
+++ b/test/form.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types';
 import yup from 'yup'
 import tsp from 'teaspoon'
 
@@ -12,7 +13,7 @@ let LeakySubmit = (props, context) => (
 )
 
 LeakySubmit.contextTypes = {
-  reactFormalContext: React.PropTypes.object
+  reactFormalContext: PropTypes.object
 }
 
 describe('Form', ()=> {


### PR DESCRIPTION
Due to `prop-types`  [compatibility](https://www.npmjs.com/package/prop-types#compatibility) I have had to update the react peer dependency from `"^0.14.0 || ^15.0.0"` to `"^0.14.9 || >=15.3.0"`

More info about this change can be found at `prop-types` [readme](https://www.npmjs.com/package/prop-types#how-to-depend-on-this-package)
