### PR TITLE
fix: stop propagation on form submit

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -430,7 +430,10 @@ const _Form: Form = React.forwardRef(
     };
 
     const handleSubmit = (e?: React.SyntheticEvent) => {
-      if (e && e.preventDefault) e.preventDefault();
+      if (e && e.preventDefault && e.stopPropagation) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
       clearPendingValidations();
       submitTimeout.set(() => submit().catch(done));
     };


### PR DESCRIPTION
- React.createPortal can nest form in a form like normal 1 tree so there is a need to stop form submit event bubbling to the parent
- https://pl.reactjs.org/docs/portals.html#event-bubbling-through-portals
@jquense 